### PR TITLE
Result for t command

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ function run(bin, args, cb) {
         let result = null;
         if (args[0] === 'l') {
             result = parseListOutput(output);
+        } else if ( args[0] === 't') {
+            result = parseListOutput(output)[0];
         }
         cb(code ? new Error('Exited with code ' + code) : null, result);
     });
@@ -95,6 +97,11 @@ function parseListOutput(str) {
         'Method': 'method',
         'Block': 'block',
         'Encrypted': 'encrypted',
+        'Type': 'type',
+        'Physical Size': 'physicalSize',
+        'Headers Size': 'headersSize',
+        'Solid': 'solid',
+        'Blocks': 'blocks',
     };
 
     if (!items.length) return [];

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,15 @@ test.serial('list', async t => {
     t.is(content.length, 6);
 });
 
+test.serial('cmd t', async t => {
+    const test = (await t2p(cb => {
+        _7z.cmd(['t', ARCH_PATH], cb);
+    }))[0];
+
+    t.is(Object.keys(test).length, 7);
+    t.is(test.type, '7z');
+});
+
 test.serial('unpack', async t => {
     await t2p(cb => {
         _7z.unpack(ARCH_PATH, UNPACK_PATH, cb);


### PR DESCRIPTION
Add result for t (Test integrity of archive) command.

```
{
    name: 'C:\\temp\\test.7z',
    type: '7z',
    physicalSize: '206',
    headersSize: '190',
    method: 'LZMA2:12 7zAES',
    solid: '-',
    blocks: '1'
}
```