### PR TITLE
add 7z output to error object

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function run(bin, args, cb) {
         if (args[0] === 'l') {
             result = parseListOutput(output);
         }
-        cb(code ? new Error('Exited with code ' + code) : null, result);
+        cb(code ? new Error(`${output}\n\n7-zip exited with code ${code}`) : null, result);
     });
     proc.stdout.on('data', (chunk) => {
         output += chunk.toString();

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function cmd(paramsArr, cb) {
 function run(bin, args, cb) {
     cb = onceify(cb);
     const runError = new Error(); // get full stack trace
-    const proc = spawn(bin, args, { windowsHide: true });
+    const proc = spawn(bin, args, {windowsHide: true});
     let output = '';
     proc.on('error', function (err) {
         cb(err);
@@ -62,7 +62,9 @@ function run(bin, args, cb) {
         if (args[0] === 'l') {
             result = parseListOutput(output);
         }
-        runError.message = `7-zip exited with code ${code}\n${output}`;
+        if (code) {
+            runError.message = `7-zip exited with code ${code}\n${output}`;
+        }
         cb(code ? runError : null, result);
     });
     proc.stdout.on('data', (chunk) => {

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function cmd(paramsArr, cb) {
 
 function run(bin, args, cb) {
     cb = onceify(cb);
+    const runError = new Error(); // get full stack trace
     const proc = spawn(bin, args, { windowsHide: true });
     let output = '';
     proc.on('error', function (err) {
@@ -61,7 +62,8 @@ function run(bin, args, cb) {
         if (args[0] === 'l') {
             result = parseListOutput(output);
         }
-        cb(code ? new Error(`${output}\n\n7-zip exited with code ${code}`) : null, result);
+        runError.message = `7-zip exited with code ${code}\n${output}`;
+        cb(code ? runError : null, result);
     });
     proc.stdout.on('data', (chunk) => {
         output += chunk.toString();

--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ function run(bin, args, cb) {
     proc.stdout.on('data', (chunk) => {
         output += chunk.toString();
     });
+    proc.stderr.on('data', (chunk) => {
+        output += chunk.toString();
+    });
 }
 
 // http://stackoverflow.com/questions/30234908/javascript-v8-optimisation-and-leaking-arguments

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function cmd(paramsArr, cb) {
 
 function run(bin, args, cb) {
     cb = onceify(cb);
-    const proc = spawn(bin, args);
+    const proc = spawn(bin, args, { windowsHide: true });
     let output = '';
     proc.on('error', function (err) {
         cb(err);

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,18 @@ test.serial('pack with "cmd"', async t => {
     t.true(exists);
 });
 
+test.serial('pack path that does not exist', async t => {
+    const wrongPath = join(__dirname, 'noPath');
+    const error = await t.throwsAsync(async () => {
+        await t2p(cb => {
+            _7z.pack(join(wrongPath), ARCH_PATH, cb);
+        });
+    });
+    // error output should contain wrong path
+    const hasWrongPathMentioning = error.message.indexOf(wrongPath) !== -1;
+    t.true(hasWrongPathMentioning);
+});
+
 test.after.always('cleanup', async t => {
     await remove(SRC_DIR_PATH);
     await remove(ARCH_PATH);


### PR DESCRIPTION
sample output:

```
Error: 
7-Zip (a) [64] 17.04 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.04 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,2 CPUs x64)

Scanning the drive for archives:
1 file, 192000 bytes (188 KiB)

Extracting archive: /tmp/test.7z
ERROR: /tmp/test.7z
/tmp/test.7z
Open ERROR: Can not open the file as [7z] archive


ERRORS:
Unexpected end of archive

Can't open as archive: 1
Files: 0
Size:       0
Compressed: 0


7-zip exited with code 2
```

at least, this gives a hint that the archive file may be an incomplete download
