### PR TITLE
Pin 7zip-bin dependency to 5.1.1 to avoid buggy 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/onikienko/7zip-min#readme",
   "dependencies": {
-    "7zip-bin": "^5.1.1"
+    "7zip-bin": "5.1.1"
   },
   "devDependencies": {
     "ava": "^4.0.1",


### PR DESCRIPTION
7zip-min depends on 7zip-bin for the 7zip executables it wraps. 7zip-bin recently published a 5.2.0 which doesn't work on Linux and macOS. An open issue is here: https://github.com/develar/7zip-bin/issues/19

This PR just pins 7zip-min to the working 5.1.1 version of 7zip-bin, to keep 7zip-min working for everyone.
