### PR TITLE
Fix "Error spawn ENOENT" when package using "pkg"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/onikienko/7zip-min#readme",
   "dependencies": {
-    "7zip-bin": "5.1.1"
+    "7zip-bin": "5.1.1",
+    "async-exit-hook": "^2.0.1"
   },
   "devDependencies": {
     "ava": "^4.0.1",


### PR DESCRIPTION
When using "pkg" to package it into binary file, we will get "Error spawn ENOENT" like https://github.com/vercel/pkg/issues/342

This commit copy 7zip to a temperary folder and execute the 7zip from there to avoid this issue